### PR TITLE
Fix drm rotation orientation

### DIFF
--- a/compositor/LayerData.h
+++ b/compositor/LayerData.h
@@ -33,6 +33,7 @@ namespace android {
 
 class DrmFbIdHandle;
 
+/* Rotation is defined in the clockwise direction */
 enum LayerTransform : uint32_t {
   kIdentity = 0,
   kFlipH = 1 << 0,

--- a/drm/DrmPlane.cpp
+++ b/drm/DrmPlane.cpp
@@ -90,14 +90,17 @@ int DrmPlane::Init() {
 
   GetPlaneProperty("zpos", zpos_property_, Presence::kOptional);
 
+  /* DRM/KMS uses counter-clockwise rotations, while HWC API uses
+   * clockwise. That's why 90 and 270 are swapped here.
+   */
   if (GetPlaneProperty("rotation", rotation_property_, Presence::kOptional)) {
     rotation_property_.AddEnumToMap("rotate-0", LayerTransform::kIdentity,
                                     transform_enum_map_);
-    rotation_property_.AddEnumToMap("rotate-90", LayerTransform::kRotate90,
+    rotation_property_.AddEnumToMap("rotate-90", LayerTransform::kRotate270,
                                     transform_enum_map_);
     rotation_property_.AddEnumToMap("rotate-180", LayerTransform::kRotate180,
                                     transform_enum_map_);
-    rotation_property_.AddEnumToMap("rotate-270", LayerTransform::kRotate270,
+    rotation_property_.AddEnumToMap("rotate-270", LayerTransform::kRotate90,
                                     transform_enum_map_);
     rotation_property_.AddEnumToMap("reflect-x", LayerTransform::kFlipH,
                                     transform_enum_map_);
@@ -200,16 +203,19 @@ bool DrmPlane::HasNonRgbFormat() const {
 
 static uint64_t ToDrmRotation(LayerTransform transform) {
   uint64_t rotation = 0;
+  /* DRM/KMS uses counter-clockwise rotations, while HWC API uses
+   * clockwise. That's why 90 and 270 are swapped here.
+   */
   if ((transform & LayerTransform::kFlipH) != 0)
     rotation |= DRM_MODE_REFLECT_X;
   if ((transform & LayerTransform::kFlipV) != 0)
     rotation |= DRM_MODE_REFLECT_Y;
   if ((transform & LayerTransform::kRotate90) != 0)
-    rotation |= DRM_MODE_ROTATE_90;
+    rotation |= DRM_MODE_ROTATE_270;
   else if ((transform & LayerTransform::kRotate180) != 0)
     rotation |= DRM_MODE_ROTATE_180;
   else if ((transform & LayerTransform::kRotate270) != 0)
-    rotation |= DRM_MODE_ROTATE_270;
+    rotation |= DRM_MODE_ROTATE_90;
   else
     rotation |= DRM_MODE_ROTATE_0;
 


### PR DESCRIPTION
Edit: upstream fix commit https://gitlab.freedesktop.org/drm-hwcomposer/drm-hwcomposer/-/merge_requests/231 works on the deck. Need verification on whether that would break intel. If it does break on intel, this PR should be modified to mirror the upstream commit and change `rotation_property_` initialization as well. If it does not break on intel, that commit should be picked onto the celadon branch and this PR should be scrapped.

For some reason, 90 and 270 hw rotations on the Steam Deck are reversed. Allow transformations to be mapped with props as a temporary solution until it can be further investigated.

For example on the deck, these props would be used before starting hwc

```
       if [ "$BOARD" == "Jupiter" ]
       then
               set_property hwc.drm.rotate_90 8
               set_property hwc.drm.rotate_270 2
       fi
```

transformation mapping bit mask can be found at https://elixir.bootlin.com/linux/v6.1.57/source/include/uapi/drm/drm_mode.h#L178